### PR TITLE
Update Trainer.cpp to allow the player to enter doors even if Ashley …

### DIFF
--- a/dllmain/Trainer.cpp
+++ b/dllmain/Trainer.cpp
@@ -975,8 +975,12 @@ void Trainer_Init()
 				regs.eax = (uint32_t)AshleyPtr();
 
 				// Make game check for Leon's position against itself, instead of checking against Ashley's position.
+				// Disables flags_STATUS_2_5024 which is set when Ashley is trapped
 				if (re4t::cfg->bTrainerAllowEnterDoorsWithoutAsh)
+				{	
+					FlagSet(GlobalPtr()->flags_STATUS_0_501C, uint32_t(Flags_STATUS::STA_SUB_CATCHED), false);
 					regs.eax = (uint32_t)PlayerPtr();
+				}
 			}
 		}; injector::MakeInline<CheckAshleyActive_hook>(pattern.count(1).get(0).get<uint32_t>(0), pattern.count(1).get(0).get<uint32_t>(5));
 	}


### PR DESCRIPTION
Rebase of https://github.com/nipkownix/re4_tweaks/pull/632

> When the "Allow entering doors without Ashley" option is enabled, it doesn't account for Ashley triggering a trap and getting stuck. In such cases, the player would be unable to enter any doors. By disabling that flag (that is checked in CheckAshleyActive), it overrides that behavior, then the player can enter doors regardless.
> 
> Test cases: I tested this in the game when it's raining after encountering Ashley and bringing her back, in the village where the church is located and many places around it, there are many traps (and doors)

